### PR TITLE
fix: remove fs preopens from welcome-tour WIT

### DIFF
--- a/welcome-tour/wit/world.wit
+++ b/welcome-tour/wit/world.wit
@@ -4,7 +4,6 @@ world hello {
   import wasi:cli/environment@0.2.3;
   import wasi:logging/logging@0.1.0-draft;
   import wasi:config/runtime@0.2.0-draft;
-  import wasi:filesystem/preopens@0.2.3;
 
   export wasi:http/incoming-handler@0.2.3;
 }


### PR DESCRIPTION
Import wasn't needed -- removing.