### PR TITLE
fix: update welcome-tour chart to use correct image

### DIFF
--- a/welcome-tour/chart/welcome-tour/values.yaml
+++ b/welcome-tour/chart/welcome-tour/values.yaml
@@ -11,7 +11,7 @@ namespace:
 # This is for setting up a WebAssembly component. 
 # More information can be found here: https://cosmonic.com/docs/api-reference/runtime.wasmcloud.dev#component
 component:
-  image: ghcr.io/cosmonic-labs/components/hello-world-hono:0.1.0
+  image: ghcr.io/cosmonic-labs/components/welcome-tour:0.1.0
   hostname: "localhost:9091"
   hostgroup: "default"
   configAddress: "http://0.0.0.0:9091"


### PR DESCRIPTION
Updates chart to use the correct, most up-to-date image. (I've also updated the [OCI artifact](https://github.com/orgs/cosmonic-labs/packages/container/package/charts%2Fwelcome-tour).)