### PR TITLE
feat: HTTP Trigger chart

### DIFF
--- a/charts/http-trigger/Chart.yaml
+++ b/charts/http-trigger/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: http-trigger
+description: Reusable HTTP Sample Chart for Cosmonic Control
+
+type: application
+version: 0.1.2
+appVersion: "0.1.2"
+
+kubeVersion: ">= 1.29.0-0"
+
+icon: https://avatars.githubusercontent.com/u/80437882
+sources:
+  - https://github.com/cosmonic
+
+maintainers:
+  - name: Cosmonic
+    url: https://github.com/orgs/cosmonic

--- a/charts/http-trigger/Makefile
+++ b/charts/http-trigger/Makefile
@@ -1,0 +1,18 @@
+all: render
+
+.PHONY: render
+render:
+	helm template -n example-ns -f  values.test.yaml example-name .
+
+.PHONY: helm-install
+helm-install:
+	helm install --create-namespace -n http-trigger -f values.test.yaml chart-dev .
+
+.PHONY: helm-delete
+helm-delete:
+	helm delete -n http-trigger --ignore-not-found --cascade foreground chart-dev
+
+.PHONY: lint
+lint:
+	@echo "Linting Helm chart..."
+	helm lint .

--- a/charts/http-trigger/templates/NOTES.txt
+++ b/charts/http-trigger/templates/NOTES.txt
@@ -1,0 +1,3 @@
+The {{ .Release.Name }} trigger has been deployed successfully.
+
+The HTTP Server is serving on http://{{ .Values.ingress.host }}.

--- a/charts/http-trigger/templates/_helpers.tpl
+++ b/charts/http-trigger/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "http-trigger.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "http-trigger.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "http-trigger.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "http-trigger.labels" -}}
+helm.sh/chart: {{ include "http-trigger.chart" . }}
+{{ include "http-trigger.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "http-trigger.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "http-trigger.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Component name - allows override via component.name
+*/}}
+{{- define "http-trigger.componentName" -}}
+{{- default (include "http-trigger.fullname" .) .Values.component.name }}
+{{- end }}
+
+{{/*
+Config name - based on component name
+*/}}
+{{- define "http-trigger.configName" -}}
+{{- printf "%s-config" (include "http-trigger.componentName" .) }}
+{{- end }}

--- a/charts/http-trigger/templates/http_trigger.yaml
+++ b/charts/http-trigger/templates/http_trigger.yaml
@@ -1,0 +1,23 @@
+apiVersion: control.cosmonic.io/v1alpha1
+kind: HTTPTrigger
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "http-trigger.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  {{- with .Values.hostSelector }}
+  hostSelector: {{ . }}
+  {{- end }}
+  {{- with .Values.hostInterfaces }}
+  hostInterfaces: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.volumes }}
+  volumes: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  ingress:
+    host: {{ .Values.ingress.host }}
+    paths: {{ toYaml .Values.ingress.paths | nindent 6 }}
+  template:
+    spec:
+      components: {{ tpl (toYaml .Values.components) . | nindent 8 }}

--- a/charts/http-trigger/values.test.yaml
+++ b/charts/http-trigger/values.test.yaml
@@ -1,0 +1,6 @@
+components:
+  - name: http
+    image: ghcr.io/cosmonic-labs/control-demos/hello-world:0.1.2
+
+ingress:
+  host: "hello.localhost.cosmonic.sh"

--- a/charts/http-trigger/values.yaml
+++ b/charts/http-trigger/values.yaml
@@ -1,0 +1,23 @@
+# A host-label selector for placement. (ex: {hostgroup: "default"})
+hostSelector: {}
+
+# Additional host interfaces (ex: wasi:logging/logging )
+hostInterfaces: []
+
+# Volumes available to all components to mount
+volumes: []
+
+# This is for setting up a WebAssembly component.
+# More information can be found here: https://cosmonic.com/docs/api-reference/runtime.wasmcloud.dev#component
+# Only one component can export wasi:http/incoming-handler
+components: []
+
+# how many copies of the components above to schedule
+replicas: 1
+
+# multiple workloads can bind to the same "host" under different paths
+ingress:
+  host: ""
+  paths:
+    - path: /
+      pathType: Prefix


### PR DESCRIPTION
To be used in conjunction with kind setup from control repo.

See [charts/http-trigger/values.test.yaml](https://github.com/cosmonic-labs/control-demos/blob/1c8741d4545c97d8774fa86cdc89ad2de21f2d42/charts/http-trigger/values.test.yaml) for minimal config.

```
http-trigger ❯ make helm-install
helm install --create-namespace -n http-trigger -f values.test.yaml chart-dev .
NAME: chart-dev
LAST DEPLOYED: Thu Sep 25 11:51:48 2025
NAMESPACE: http-trigger
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The chart-dev trigger has been deployed successfully.

The HTTP Server is serving on http://hello.localhost.cosmonic.sh.
```


(wait a bit)

```
http-trigger ❯ curl hello.localhost.cosmonic.sh -i
HTTP/1.1 200 OK
date: Thu, 25 Sep 2025 15:52:06 GMT
x-envoy-upstream-service-time: 0
server: envoy
transfer-encoding: chunked

Hello from Cosmonic Control!
```