### PR TITLE
Update to use HTTPTrigger

### DIFF
--- a/blobstore-nats/README.md
+++ b/blobstore-nats/README.md
@@ -57,22 +57,16 @@ config:
       domain: default
 ```
 
-Deploy this demo to a Kubernetes cluster with Cosmonic Control and NATS using the included Helm chart:
+Deploy this demo to a Kubernetes cluster with Cosmonic Control and NATS using the shared HTTP trigger chart:
 
 ```shell
-helm install blobstore-nats ./chart/blobstore-nats
+helm install blobstore-nats ../../charts/http-trigger -f values.yaml
 ```
 
 The chart is also available as an OCI artifact:
 
 ```shell
-helm install blobstore-nats oci://ghcr.io/cosmonic-labs/charts/blobstore-nats --version 0.1.0
-```
-
-You can also deploy with the included CRD manifests:
-
-```shell
-kubectl apply -f ./manifests/
+helm install http-server oci://ghcr.io/cosmonic-labs/charts/http-trigger:0.1.2 -f values.yaml
 ```
 
 ## Contents
@@ -80,8 +74,6 @@ kubectl apply -f ./manifests/
 In addition to the standard elements of a Rust project, the template directory includes the following files and directories:
 
 - `wit/`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
-- `manifests/`: Example CRD deployment manifests for Kubernetes clusters with Cosmonic Control
-- `chart/`: Helm chart
 
 ## Build Dependencies
 

--- a/blobstore-nats/values.yaml
+++ b/blobstore-nats/values.yaml
@@ -1,0 +1,15 @@
+# For the 'http-trigger' helm chart
+components:
+  - name: blobstore-nats
+    image: ghcr.io/cosmonic-labs/control-demos/http-blobstore:0.1.0
+
+ingress:
+  host: "blobstore-nats.localhost.cosmonic.sh"
+
+hostInterfaces:
+  - namespace: wasi
+    package: blobstore
+    version: 0.2.0-draft
+    interfaces:
+      - blobstore
+      - container

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,10 @@
+# Helm charts for Cosmonic Control 
+
+This directory contains Helm charts for deploying WebAssembly (Wasm) applications to Kubernetes using [Cosmonic Control](https://cosmonic.com/). In order to use these charts, you will need a **Kubernetes cluster** and an **installation of Cosmonic Control**.
+
+Sign up for Cosmonic Control's [free trial](https://cosmonic.com/trial) to get a `cosmonicLicenseKey`.
+
+## Contents
+
+* `http-sample`: A reusable Helm chart for deploying HTTP components in Cosmonic Control.
+* `http-trigger`: A reusable Helm chart for quickly and easily deploying HTTP components to Cosmonic Control with automatic ingress configuration.

--- a/charts/http-trigger/README.md
+++ b/charts/http-trigger/README.md
@@ -1,0 +1,77 @@
+# HTTP Trigger Helm Chart
+
+This is a reusable Helm chart for deploying HTTP components with automatic ingress in Cosmonic Control. The chart deploys a component using Cosmonic Control's [HTTPTrigger CRD](https://cosmonic.com/docs/custom-resources#httptrigger).
+
+## Usage
+
+Deploy any of the HTTP components using this single chart with different values files:
+
+### HTTP Server
+
+```bash
+helm install http-server ./charts/http-trigger -f ../../http-server/values.http-trigger.yaml
+```
+
+### Hono Swagger UI
+
+```bash
+helm install hono-swagger-ui ./charts/http-trigger -f ../../hono-swagger-ui/values.http-trigger.yaml
+```
+
+### Welcome Tour
+
+```bash
+helm install welcome-tour ./charts/http-trigger -f ../../welcome-tour/values.http-trigger.yaml
+```
+
+## Configuration
+
+The chart supports the following key configuration options:
+
+- `component.name`: Name of the component
+- `component.image`: Container image for the component
+- `replicas`: How many copies of the components above to schedule (default: `1`)
+- `ingress.host`: Hostname used for ingress
+- `ingress.paths.path`: Multiple workloads can bind to the same "host" under different paths. (default: `/`)
+- `ingress.paths.pathType`: Multiple workloads can bind to the same "host" under different paths. (default: `Prefix`)
+
+### Configuration with additional host interfaces
+
+You can use the `hostInterfaces` field to deploy a component that uses other available host interfaces in addition to HTTP. `hostInterfaces` requires the following subfields:
+
+* `namespace`
+* `package`
+* `version`
+* `interfaces`
+
+Below is an example adding the blobstore interface for the [Blobby](../../blobby/) demo:
+
+```yaml
+# For the 'http-trigger' helm chart
+components:
+  - name: blobby
+    image: ghcr.io/cosmonic-labs/components/blobby:0.2.0
+
+ingress:
+  host: "blobby.localhost.cosmonic.sh"
+
+hostInterfaces:
+  - namespace: wasi
+    package: blobstore
+    version: 0.2.0-draft
+    interfaces:
+      - blobstore
+  - namespace: wasi
+    package: logging
+    version: 0.1.0-draft
+    interfaces:
+      - logging
+```
+
+## Custom Values Files
+
+Each HTTP sample contains its own `values.http-trigger.yaml` file in its respective directory:
+
+- `../../http-server/values.http-trigger.yaml`: Configuration for the HTTP server sample
+- `../../hono-swagger-ui/values.http-trigger.yaml`: Configuration for the Hono Swagger UI sample  
+- `../../welcome-tour/values.http-trigger.yaml`: Configuration for the Welcome Tour sample

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -22,10 +22,16 @@ helm install hostgroup oci://ghcr.io/cosmonic/cosmonic-control-hostgroup --versi
 
 ## Deploy with Cosmonic Control
 
-Deploy this template to a Kubernetes cluster with Cosmonic Control using the included CRD manifest:
+Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP trigger chart:
 
 ```shell
-kubectl apply -f ./manifests/component.yaml
+helm install hello-world ../../charts/http-trigger -f values.yaml
+```
+
+The chart is also available as an OCI artifact:
+
+```shell
+helm install http-server oci://ghcr.io/cosmonic-labs/charts/http-trigger:0.1.2 -f values.yaml
 ```
 
 ## Contents
@@ -33,9 +39,8 @@ kubectl apply -f ./manifests/component.yaml
 In addition to the standard elements of a Rust project, the template directory includes the following files and directories:
 
 - `wit/`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
-- `manifests/`: Example CRD deployment manifests for Kubernetes clusters with Cosmonic Control
 
-There is also a GitHub Workflow `hello-world.yml` in the `.github/workflows` directory at the root of `control-demos` that is triggered on release. This workflow uses the [`setup-wash` GitHub Action](https://github.com/wasmCloud/setup-wash-action) to build the component and push an OCI artifact to GHCR, then updates the manifest in the `manifests/` subdirectory to reflect the latest version. The workflow should work in your own fork and can be adapted for other Rust-based Wasm components with minimal changes. 
+There is also a GitHub Workflow `hello-world.yml` in the `.github/workflows` directory at the root of `control-demos` that is triggered on release. This workflow uses the [`setup-wash` GitHub Action](https://github.com/wasmCloud/setup-wash-action) to build the component and push an OCI artifact to GHCR. The workflow should work in your own fork and can be adapted for other Rust-based Wasm components with minimal changes. 
 
 ## Build Dependencies
 

--- a/hello-world/values.yaml
+++ b/hello-world/values.yaml
@@ -1,0 +1,7 @@
+# For the 'http-trigger' helm chart
+components:
+  - name: hello-world
+    image: ghcr.io/cosmonic-labs/control-demos/hello-world:0.1.2
+
+ingress:
+  host: "hello-world.localhost.cosmonic.sh"

--- a/hono-swagger-ui/README.md
+++ b/hono-swagger-ui/README.md
@@ -15,16 +15,16 @@ helm install hostgroup oci://ghcr.io/cosmonic/cosmonic-control-hostgroup --versi
 
 ## Deploy with Cosmonic Control
 
-Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP sample chart:
+Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP trigger chart:
 
 ```shell
-helm install hono-swagger-ui ../../charts/http-sample -f values.yaml -n hono-swagger-ui --create-namespace
+helm install hono-swagger-ui ../../charts/http-trigger -f values.http-trigger.yaml -n hono-swagger-ui --create-namespace
 ```
 
 The chart is also available as an OCI artifact:
 
 ```shell
-helm install hono-swagger-ui oci://ghcr.io/cosmonic-labs/charts/http-sample -f values.yaml -n hono-swagger-ui --create-namespace
+helm install hono-swagger-ui oci://ghcr.io/cosmonic-labs/charts/http-trigger:0.1.2 -f values.http-trigger.yaml -n hono-swagger-ui --create-namespace
 ```
 
 ## Running the Kubernetes demo

--- a/hono-swagger-ui/values.http-trigger.yaml
+++ b/hono-swagger-ui/values.http-trigger.yaml
@@ -1,0 +1,7 @@
+# For the 'http-trigger' helm chart
+components:
+  - name: hono-swagger-ui
+    image: ghcr.io/cosmonic-labs/control-demos/hono-swagger-ui:0.1.2
+
+ingress:
+  host: "hono-swagger-ui.localhost.cosmonic.sh"

--- a/http-server/README.md
+++ b/http-server/README.md
@@ -20,16 +20,16 @@ helm install hostgroup oci://ghcr.io/cosmonic/cosmonic-control-hostgroup --versi
 
 ## Deploy with Cosmonic Control
 
-Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP sample chart:
+Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP trigger chart:
 
 ```shell
-helm install http-server ../../charts/http-sample -f values.yaml
+helm install http-server ../../charts/http-trigger -f values.http-trigger.yaml
 ```
 
 The chart is also available as an OCI artifact:
 
 ```shell
-helm install http-server oci://ghcr.io/cosmonic-labs/charts/http-sample -f values.yaml
+helm install http-server oci://ghcr.io/cosmonic-labs/charts/http-trigger:0.1.2 -f values.http-trigger.yaml
 ```
 
 ## Running on Kubernetes

--- a/http-server/values.http-trigger.yaml
+++ b/http-server/values.http-trigger.yaml
@@ -1,0 +1,7 @@
+# For the 'http-trigger' helm chart
+components:
+  - name: http-server
+    image: ghcr.io/cosmonic-labs/control-demos/http-server:0.1.2
+
+ingress:
+  host: "http-server.localhost.cosmonic.sh"

--- a/welcome-tour/README.md
+++ b/welcome-tour/README.md
@@ -18,16 +18,16 @@ helm install hostgroup oci://ghcr.io/cosmonic/cosmonic-control-hostgroup --versi
 
 ## Deploy with Cosmonic Control
 
-Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP sample chart:
+Deploy this component to a Kubernetes cluster with Cosmonic Control using the shared HTTP trigger chart:
 
 ```shell
-helm install welcome-tour ../../charts/http-sample -f values.yaml -n welcome-app --create-namespace
+helm install welcome-tour ../../charts/http-trigger -f values.http-trigger.yaml -n welcome-app --create-namespace
 ```
 
 The chart is also available as an OCI artifact:
 
 ```shell
-helm install welcome-tour oci://ghcr.io/cosmonic-labs/charts/http-sample -f values.yaml -n welcome-app --create-namespace
+helm install welcome-tour oci://ghcr.io/cosmonic-labs/charts/http-trigger:0.1.2 -f values.http-trigger.yaml -n welcome-app --create-namespace
 ```
 
 ## Running the Kubernetes demo
@@ -36,7 +36,8 @@ In separate terminal tabs:
 
 ```bash
 kubectl -n cosmonic-system port-forward svc/console 8080:8080
-
+```
+```bash
 kubectl -n cosmonic-system port-forward svc/hostgroup-default 9091:9091
 ```
 
@@ -46,7 +47,11 @@ See some of the resources running with:
 
 ```bash
 kubectl get hosts
+```
+```bash
 kubectl get components -A
+```
+```bash
 kubectl get providers -A
 ```
 
@@ -54,10 +59,17 @@ kubectl get providers -A
 
 ```bash
 helm uninstall welcome-tour -n welcome-app
+```
+```bash
 kubectl delete ns welcome-app
-
+```
+```bash
 helm uninstall hostgroup -n cosmonic-system
+```
+```bash
 helm uninstall cosmonic-control -n cosmonic-system
+```
+```bash
 kubectl delete ns cosmonic-system
 ```
 

--- a/welcome-tour/values.http-trigger.yaml
+++ b/welcome-tour/values.http-trigger.yaml
@@ -1,0 +1,7 @@
+# For the 'http-trigger' helm chart
+components:
+  - name: welcome-tour
+    image: ghcr.io/cosmonic-labs/control-demos/welcome-tour:0.1.2
+
+ingress:
+  host: "welcome-tour.localhost.cosmonic.sh"


### PR DESCRIPTION
Updates examples to use HTTPTrigger chart for deployment, and adds readme for the chart itself.