### PR TITLE
Update minimum k8s version to 1.24

### DIFF
--- a/charts/http-trigger/Chart.yaml
+++ b/charts/http-trigger/Chart.yaml
@@ -3,10 +3,10 @@ name: http-trigger
 description: Reusable HTTP Sample Chart for Cosmonic Control
 
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"
 
-kubeVersion: ">= 1.29.0-0"
+kubeVersion: ">= 1.24.0-0"
 
 icon: https://avatars.githubusercontent.com/u/80437882
 sources:


### PR DESCRIPTION
This change just lowers the minimum Kubernetes version to 1.24. 

Tested with a local Kind cluster running k8s 1.24 using:
```bash
cat <<EOF | kind create cluster --image kindest/node:v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51 --config=-
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 30080
    hostPort: 80
    protocol: TCP
  - containerPort: 30443
    hostPort: 443
    protocol: TCP
EOF
```