### PR TITLE
fix(hono-swagger-ui): redirect / to the Swagger UI

### DIFF
--- a/hono-swagger-ui/README.md
+++ b/hono-swagger-ui/README.md
@@ -2,6 +2,15 @@
 
 This Wasm component is a tool for documenting and testing RESTful APIs, built on the [Hono HTTP framework](https://hono.dev/docs/) and the [Swagger UI](https://swagger.io/docs/open-source-tools/swagger-ui/usage/installation/) middleware. The component provides an interactive documentation interface based on a given OpenAPI specification. 
 
+## Routes
+
+| Path      | Serves                                                        |
+| --------- | ------------------------------------------------------------- |
+| `/`       | Redirects to `/ui` (so the default URL lands on the docs).    |
+| `/ui`     | The interactive Swagger UI.                                   |
+| `/doc`    | The OpenAPI document (JSON) that the UI renders.              |
+| `/health` | A plain `OK` health check.                                    |
+
 ### Install local Kubernetes environment
 
 For local Kubernetes development, we recommend [`kind`](https://kind.sigs.k8s.io/) with host ports 80 and 443 forwarded to Traefik's NodePorts (the Cosmonic Control chart deploys Traefik as the edge proxy by default):

--- a/hono-swagger-ui/src/index.ts
+++ b/hono-swagger-ui/src/index.ts
@@ -34,6 +34,10 @@ const openApiDoc = {
 // Middleware for logging
 app.use(wasiLog());
 
+// Land the root on the Swagger UI, so the default URL
+// (http://hono-swagger-ui.localhost:8200/) opens the docs instead of a 404 (#167).
+app.get("/", (c: Context) => c.redirect("/ui"));
+
 // Serve the OpenAPI document
 app.get("/doc", (c: Context) => c.json(openApiDoc));
 


### PR DESCRIPTION
Resolves cosmonic/desktop#167.

The Hono app served `/ui` (Swagger UI), `/doc` (OpenAPI JSON), and `/health`, but `/` was unhandled and fell through to the 404 handler — so the default Launchpad URL `http://hono-swagger-ui.localhost:8200/` landed on a 404.

- Redirect `/` → `/ui` so the default URL opens the docs.
- Add a Routes table to the README (the issue's optional "add doc").

Verified with `wash dev`: `GET /` → `302 Location: /ui` → SwaggerUI 200.

Publishing the image happens on the next tagged release (`http-samples.yml`), which republishes `ghcr.io/cosmonic-labs/control-demos/hono-swagger-ui:<version>`; the Launchpad entry will be repointed to the new digest.